### PR TITLE
Allow configurable rollup on ALB Healthy Host Count check

### DIFF
--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -117,9 +117,9 @@ resource "datadog_monitor" "no_healthy_instances" {
 
   query = <<END
     min(${var.no_healthy_instances_evaluation_window}): (
-      sum:aws.applicationelb.healthy_host_count.minimum${local.query_filter} by {aws_account,env,datadog_managed,region,loadbalancer} / (
-      sum:aws.applicationelb.healthy_host_count.minimum${local.query_filter} by {aws_account,env,datadog_managed,region,loadbalancer} +
-      sum:aws.applicationelb.un_healthy_host_count.maximum${local.query_filter} by {aws_account,env,datadog_managed,region,loadbalancer} )
+      sum:aws.applicationelb.healthy_host_count${local.query_filter} by {aws_account,env,datadog_managed,region,loadbalancer}.${var.no_healthy_instances_rollup}() / (
+      sum:aws.applicationelb.healthy_host_count${local.query_filter} by {aws_account,env,datadog_managed,region,loadbalancer}.${var.no_healthy_instances_rollup}() +
+      sum:aws.applicationelb.un_healthy_host_count${local.query_filter} by {aws_account,env,datadog_managed,region,loadbalancer}.${var.no_healthy_instances_rollup}() )
     ) * 100 <= ${var.no_healthy_instances_threshold_critical}
 END
 

--- a/aws/alb/variables.tf
+++ b/aws/alb/variables.tf
@@ -163,6 +163,12 @@ variable "no_healthy_instances_threshold_warning" {
   type        = number
 }
 
+variable "no_healthy_instances_rollup" {
+  default     = "weighted"
+  description = "Rollup aggregation for host count metrics (avg, min, max, sum, weighted). Defaults to weighted to avoid false alerts from transient CloudWatch minimum values during ECS scaling events."
+  type        = string
+}
+
 variable "no_healthy_instances_use_message" {
   description = "Whether to use the query alert base message"
   type        = bool


### PR DESCRIPTION
We were getting a ton of noise from this, it seems to stem from the alb healthy hosts check looking at healthy_hosts_count.minimum, which can hit 0 at a single point in the standard 60 second rollup window (when instances are draining connections for example), but isn't necessarily indicative of an outage.  The new default `.weighted()` is more indicative of a host health problem.