### PR TITLE
update synthetic alerts to not fire without resolution

### DIFF
--- a/common/common.tf
+++ b/common/common.tf
@@ -340,6 +340,7 @@ END
 ${local.alert_context}
 **Alert Information**
 {{#is_alert}} ${local.notify_on_alert} {{/is_alert}}
+{{#is_recovery}} ${local.notify_on_alert} {{/is_recovery}}
 END
 
   event_alert_base_message = <<END
@@ -348,7 +349,6 @@ ${local.alert_context}
 **Alert Information**
 * **Event Tags**: {{event.tags}}
 * **Event Text**: {{event.text}}
-{{#is_alert}}
 Current value: {{value}}
 Threshold: {{threshold}}
 
@@ -367,7 +367,6 @@ Environment: {{env.name}}
   {{/is_match}}
 
 Please investigate and take necessary actions.
-{{/is_alert}}
 END
 
   service_group_by = join(",", formatlist("\"%s\"", var.group_by))

--- a/common/common.tf
+++ b/common/common.tf
@@ -349,6 +349,7 @@ ${local.alert_context}
 **Alert Information**
 * **Event Tags**: {{event.tags}}
 * **Event Text**: {{event.text}}
+{{#is_alert}}
 Current value: {{value}}
 Threshold: {{threshold}}
 
@@ -367,6 +368,8 @@ Environment: {{env.name}}
   {{/is_match}}
 
 Please investigate and take necessary actions.
+{{/is_alert}}
+{{#is_recovery}} ${local.notify_on_alert} {{/is_recovery}}
 END
 
   service_group_by = join(",", formatlist("\"%s\"", var.group_by))


### PR DESCRIPTION
A few of the synthetic monitors use is_alert to notify but don't do anything for is_recovery.  I've changed to either use both or neither.